### PR TITLE
Enable all RHEL tasks and add update security toggle

### DIFF
--- a/inventories/group_vars/RHEL.yml
+++ b/inventories/group_vars/RHEL.yml
@@ -34,5 +34,8 @@ rhel9_var_PassAuth: "PasswordAuthentication yes"
 #logindefs
 rhel9_var_PassMinDays: "PASS_MIN_DAYS 1"
 
+# update-security
+rhel9_var_update_security: true
+
 
 

--- a/roles/set_rhel/redhat_aws.yml
+++ b/roles/set_rhel/redhat_aws.yml
@@ -5,19 +5,19 @@
   tasks:
     - ansible.builtin.import_tasks: tasks/set_hostname.yml
     - ansible.builtin.import_tasks: tasks/set_kdump.yml
-#    - ansible.builtin.import_tasks: tasks/set_firewall.yml
+    - ansible.builtin.import_tasks: tasks/set_firewall.yml
     - ansible.builtin.import_tasks: tasks/set_locale.yml
     - ansible.builtin.import_tasks: tasks/set_timezone.yml
     - ansible.builtin.import_tasks: tasks/set_selinux.yml
-#    - ansible.builtin.import_tasks: tasks/set_smartd.yml
+    - ansible.builtin.import_tasks: tasks/set_smartd.yml
     - ansible.builtin.import_tasks: tasks/set_blackout.yml
     - ansible.builtin.import_tasks: tasks/set_break.yml
     - ansible.builtin.import_tasks: tasks/set_runlevel.yml
-#    - ansible.builtin.import_tasks: tasks/set_ssh_port.yml
+    - ansible.builtin.import_tasks: tasks/set_ssh_port.yml
     - ansible.builtin.import_tasks: tasks/set_ssh_rootLogin.yml
-#    - ansible.builtin.import_tasks: tasks/set_ntp.yml
-#    - ansible.builtin.import_tasks: tasks/set_leapsecmode_azure.yml
-#    - ansible.builtin.import_tasks: tasks/set_leapsecmode_aws.yml
+    - ansible.builtin.import_tasks: tasks/set_ntp.yml
+    - ansible.builtin.import_tasks: tasks/set_leapsecmode_azure.yml
+    - ansible.builtin.import_tasks: tasks/set_leapsecmode_aws.yml
     - ansible.builtin.import_tasks: tasks/set_hosts.yml
     - ansible.builtin.import_tasks: tasks/set_pass_rules.yml
     - ansible.builtin.import_tasks: tasks/set_pass_days.yml

--- a/roles/set_rhel/tasks/set_update_security.yml
+++ b/roles/set_rhel/tasks/set_update_security.yml
@@ -5,16 +5,20 @@
   register: command_result
   changed_when: false
   failed_when: false
+  when: rhel9_var_update_security | default(false)
   become: true
 - name: Set subscription-manager.conf
   ansible.builtin.shell:
     sed -i -e 's/^enabled=1/enabled=0/g' /etc/yum/pluginconf.d/subscription-manager.conf
   changed_when: false
-  when: command_result.rc
+  when:
+    - rhel9_var_update_security | default(false)
+    - command_result.rc
   become: true
 - name: Yum UpdateSecurity
   yum:
     name: '*'
     security: true
     state: latest
+  when: rhel9_var_update_security | default(false)
   become: true


### PR DESCRIPTION
## Summary
- enable all tasks in `redhat_aws.yml`
- guard `set_update_security` tasks behind a variable
- add `rhel9_var_update_security` variable

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6874b307b7d4832fbb4ce0f24e18c0cf