### PR TITLE
Enable additional RHEL tasks

### DIFF
--- a/inventories/group_vars/RHEL.yml
+++ b/inventories/group_vars/RHEL.yml
@@ -34,5 +34,40 @@ rhel9_var_PassAuth: "PasswordAuthentication yes"
 #logindefs
 rhel9_var_PassMinDays: "PASS_MIN_DAYS 1"
 
+# update-security
+rhel9_var_update_security: true
 
 
+
+# instance logging
+rhel9_var_instance_logging: false
+
+# DNS servers
+rhel9_var_dns:
+  - 8.8.8.8
+  - 8.8.4.4
+
+# peer DNS setting
+rhel9_var_peer_dns: "yes"
+
+# swap size in MB
+rhel9_var_swap_size_mb: 1024
+
+# partition device
+rhel9_var_partition_device: /dev/sdb
+rhel9_var_partition_size: 10G
+
+# account lockout attempts
+rhel9_var_account_lockout_attempts: 5
+
+# root password
+rhel9_var_root_password: "Passw0rd!"
+
+# check update flag
+rhel9_var_check_update: false
+
+# os version (display only)
+rhel9_var_os_version: RHEL9
+
+# file limit
+rhel9_var_file_limit: 65535

--- a/roles/set_rhel/redhat_aws.yml
+++ b/roles/set_rhel/redhat_aws.yml
@@ -5,19 +5,19 @@
   tasks:
     - ansible.builtin.import_tasks: tasks/set_hostname.yml
     - ansible.builtin.import_tasks: tasks/set_kdump.yml
-#    - ansible.builtin.import_tasks: tasks/set_firewall.yml
+    - ansible.builtin.import_tasks: tasks/set_firewall.yml
     - ansible.builtin.import_tasks: tasks/set_locale.yml
     - ansible.builtin.import_tasks: tasks/set_timezone.yml
     - ansible.builtin.import_tasks: tasks/set_selinux.yml
-#    - ansible.builtin.import_tasks: tasks/set_smartd.yml
+    - ansible.builtin.import_tasks: tasks/set_smartd.yml
     - ansible.builtin.import_tasks: tasks/set_blackout.yml
     - ansible.builtin.import_tasks: tasks/set_break.yml
     - ansible.builtin.import_tasks: tasks/set_runlevel.yml
-#    - ansible.builtin.import_tasks: tasks/set_ssh_port.yml
+    - ansible.builtin.import_tasks: tasks/set_ssh_port.yml
     - ansible.builtin.import_tasks: tasks/set_ssh_rootLogin.yml
-#    - ansible.builtin.import_tasks: tasks/set_ntp.yml
-#    - ansible.builtin.import_tasks: tasks/set_leapsecmode_azure.yml
-#    - ansible.builtin.import_tasks: tasks/set_leapsecmode_aws.yml
+    - ansible.builtin.import_tasks: tasks/set_ntp.yml
+    - ansible.builtin.import_tasks: tasks/set_leapsecmode_azure.yml
+    - ansible.builtin.import_tasks: tasks/set_leapsecmode_aws.yml
     - ansible.builtin.import_tasks: tasks/set_hosts.yml
     - ansible.builtin.import_tasks: tasks/set_pass_rules.yml
     - ansible.builtin.import_tasks: tasks/set_pass_days.yml
@@ -25,3 +25,13 @@
     - ansible.builtin.import_tasks: tasks/add_group.yml
     - ansible.builtin.import_tasks: tasks/add_user.yml
     - ansible.builtin.import_tasks: tasks/set_update_security.yml
+    - ansible.builtin.import_tasks: tasks/check_instance_logging.yml
+    - ansible.builtin.import_tasks: tasks/set_dns.yml
+    - ansible.builtin.import_tasks: tasks/set_peer_dns.yml
+    - ansible.builtin.import_tasks: tasks/set_swap.yml
+    - ansible.builtin.import_tasks: tasks/set_partition.yml
+    - ansible.builtin.import_tasks: tasks/set_account_lockout.yml
+    - ansible.builtin.import_tasks: tasks/set_root_password.yml
+    - ansible.builtin.import_tasks: tasks/check_update.yml
+    - ansible.builtin.import_tasks: tasks/set_os_version.yml
+    - ansible.builtin.import_tasks: tasks/set_filelimit.yml

--- a/roles/set_rhel/tasks/check_instance_logging.yml
+++ b/roles/set_rhel/tasks/check_instance_logging.yml
@@ -1,0 +1,22 @@
+---
+- name: Get instance id
+  ansible.builtin.shell: curl -s http://169.254.169.254/latest/meta-data/instance-id
+  register: instance_id
+  changed_when: false
+  failed_when: false
+  when: rhel9_var_instance_logging | default(false)
+
+- name: Enable persistent journald
+  ansible.builtin.lineinfile:
+    path: /etc/systemd/journald.conf
+    regexp: '^#?Storage='
+    line: 'Storage=persistent'
+  when: rhel9_var_instance_logging | default(false)
+  become: true
+
+- name: Restart journald
+  ansible.builtin.service:
+    name: systemd-journald
+    state: restarted
+  when: rhel9_var_instance_logging | default(false)
+  become: true

--- a/roles/set_rhel/tasks/check_update.yml
+++ b/roles/set_rhel/tasks/check_update.yml
@@ -1,0 +1,13 @@
+---
+- name: Check for package updates
+  ansible.builtin.shell: yum check-update
+  register: update_info
+  changed_when: false
+  failed_when: false
+  when: rhel9_var_check_update | default(false)
+
+- name: Display kernel version
+  ansible.builtin.shell: uname -r
+  register: kernel_version
+  changed_when: false
+  when: rhel9_var_check_update | default(false)

--- a/roles/set_rhel/tasks/set_account_lockout.yml
+++ b/roles/set_rhel/tasks/set_account_lockout.yml
@@ -1,0 +1,18 @@
+---
+- name: Configure account lockout in system-auth
+  ansible.builtin.lineinfile:
+    path: /etc/pam.d/system-auth
+    regexp: '^auth.*pam_faillock.so'
+    line: "auth        required      pam_faillock.so preauth silent deny={{ rhel9_var_account_lockout_attempts }} unlock_time=900"
+    backrefs: yes
+  when: rhel9_var_account_lockout_attempts is defined
+  become: true
+
+- name: Configure account lockout in password-auth
+  ansible.builtin.lineinfile:
+    path: /etc/pam.d/password-auth
+    regexp: '^auth.*pam_faillock.so'
+    line: "auth        required      pam_faillock.so preauth silent deny={{ rhel9_var_account_lockout_attempts }} unlock_time=900"
+    backrefs: yes
+  when: rhel9_var_account_lockout_attempts is defined
+  become: true

--- a/roles/set_rhel/tasks/set_dns.yml
+++ b/roles/set_rhel/tasks/set_dns.yml
@@ -1,0 +1,10 @@
+---
+- name: Configure DNS servers
+  ansible.builtin.lineinfile:
+    path: /etc/resolv.conf
+    line: "nameserver {{ item }}"
+    state: present
+    create: yes
+  loop: "{{ rhel9_var_dns }}"
+  when: rhel9_var_dns is defined
+  become: true

--- a/roles/set_rhel/tasks/set_filelimit.yml
+++ b/roles/set_rhel/tasks/set_filelimit.yml
@@ -1,0 +1,8 @@
+---
+- name: Set file descriptor limit
+  ansible.builtin.lineinfile:
+    path: /etc/security/limits.conf
+    line: "* soft nofile {{ rhel9_var_file_limit }}"
+    create: yes
+  when: rhel9_var_file_limit is defined
+  become: true

--- a/roles/set_rhel/tasks/set_os_version.yml
+++ b/roles/set_rhel/tasks/set_os_version.yml
@@ -1,0 +1,6 @@
+---
+- name: Display OS version
+  ansible.builtin.shell: cat /etc/redhat-release
+  register: os_version
+  changed_when: false
+  when: rhel9_var_os_version is defined

--- a/roles/set_rhel/tasks/set_partition.yml
+++ b/roles/set_rhel/tasks/set_partition.yml
@@ -1,0 +1,11 @@
+---
+- name: Create data partition
+  community.general.parted:
+    device: "{{ rhel9_var_partition_device }}"
+    number: 1
+    state: present
+    part_end: "{{ rhel9_var_partition_size }}"
+  when:
+    - rhel9_var_partition_device is defined
+    - rhel9_var_partition_size is defined
+  become: true

--- a/roles/set_rhel/tasks/set_peer_dns.yml
+++ b/roles/set_rhel/tasks/set_peer_dns.yml
@@ -1,0 +1,9 @@
+---
+- name: Configure PEERDNS
+  ansible.builtin.lineinfile:
+    path: "/etc/sysconfig/network-scripts/ifcfg-{{ rhel9_var_interface | default('eth0') }}"
+    regexp: '^PEERDNS='
+    line: "PEERDNS={{ rhel9_var_peer_dns }}"
+    create: yes
+  when: rhel9_var_peer_dns is defined
+  become: true

--- a/roles/set_rhel/tasks/set_root_password.yml
+++ b/roles/set_rhel/tasks/set_root_password.yml
@@ -1,0 +1,7 @@
+---
+- name: Set root password
+  ansible.builtin.user:
+    name: root
+    password: "{{ rhel9_var_root_password | password_hash('sha512') }}"
+  when: rhel9_var_root_password is defined
+  become: true

--- a/roles/set_rhel/tasks/set_swap.yml
+++ b/roles/set_rhel/tasks/set_swap.yml
@@ -1,0 +1,35 @@
+---
+- name: Check current swap
+  ansible.builtin.command: swapon --show
+  register: swap_result
+  changed_when: false
+  become: true
+
+- name: Create swap file
+  ansible.builtin.shell: |
+    dd if=/dev/zero of=/swapfile bs=1M count={{ rhel9_var_swap_size_mb }}
+    chmod 600 /swapfile
+    mkswap /swapfile
+  when:
+    - rhel9_var_swap_size_mb is defined
+    - swap_result.stdout == ""
+  become: true
+
+- name: Enable swap file
+  ansible.builtin.command: swapon /swapfile
+  when:
+    - rhel9_var_swap_size_mb is defined
+    - swap_result.stdout == ""
+  become: true
+
+- name: Persist swap in fstab
+  ansible.builtin.mount:
+    name: none
+    src: /swapfile
+    fstype: swap
+    opts: sw
+    state: present
+  when:
+    - rhel9_var_swap_size_mb is defined
+    - swap_result.stdout == ""
+  become: true

--- a/roles/set_rhel/tasks/set_update_security.yml
+++ b/roles/set_rhel/tasks/set_update_security.yml
@@ -5,16 +5,20 @@
   register: command_result
   changed_when: false
   failed_when: false
+  when: rhel9_var_update_security | default(false)
   become: true
 - name: Set subscription-manager.conf
   ansible.builtin.shell:
     sed -i -e 's/^enabled=1/enabled=0/g' /etc/yum/pluginconf.d/subscription-manager.conf
   changed_when: false
-  when: command_result.rc
+  when:
+    - rhel9_var_update_security | default(false)
+    - command_result.rc
   become: true
 - name: Yum UpdateSecurity
   yum:
     name: '*'
     security: true
     state: latest
+  when: rhel9_var_update_security | default(false)
   become: true


### PR DESCRIPTION
## Summary
- add numerous RHEL configuration variables
- import new setup tasks in `redhat_aws.yml`
- implement tasks for instance logging, DNS, PEERDNS, swap, partitions, account lockout, root password, update checks, OS version and file limit

## Testing
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6874b307b7d4832fbb4ce0f24e18c0cf