### PR TITLE
Add Windows disk, network, and CrowdStrike tasks

### DIFF
--- a/inventories/group_vars/windows.yml
+++ b/inventories/group_vars/windows.yml
@@ -132,3 +132,22 @@ win_var_winupdate:
 
 # ワークグループ名
 win_var_workgroup: WORKGROUP
+
+# ディスク設定
+win_var_disk:
+  number: 1
+  letter: D
+  filesystem: NTFS
+  label: Data
+
+# ネットワークインタフェース設定
+win_var_network:
+  interface: Ethernet0
+  address: 192.168.1.100
+  prefix: 24
+  gateway: 192.168.1.1
+
+# CrowdStrike インストーラ設定
+win_var_crowdstrike:
+  installer: C:\Temp\CSInstaller.exe
+  cid: "XXXXXXXXXX"

--- a/roles/set_windows/main.yml
+++ b/roles/set_windows/main.yml
@@ -32,4 +32,7 @@
     - include: tasks/set_eventlog.yml
     - include: tasks/set_install_feature.yml
     - include: tasks/set_uninstall_feature.yml
+    - include: tasks/set_disk.yml
+    - include: tasks/set_network_interface.yml
+    - include: tasks/install_crowdstrike.yml
     - include: tasks/set_winupdate.yml

--- a/roles/set_windows/tasks/install_crowdstrike.yml
+++ b/roles/set_windows/tasks/install_crowdstrike.yml
@@ -1,0 +1,13 @@
+---
+# Install CrowdStrike sensor
+- name: Install CrowdStrike
+  ansible.windows.win_package:
+    path: "{{ win_var_crowdstrike.installer }}"
+    arguments: "/quiet /norestart CID={{ win_var_crowdstrike.cid }}"
+  when: win_var_crowdstrike is defined
+
+- name: Ensure CrowdStrike service running
+  ansible.windows.win_service:
+    name: csagent
+    state: started
+  when: win_var_crowdstrike is defined

--- a/roles/set_windows/tasks/set_disk.yml
+++ b/roles/set_windows/tasks/set_disk.yml
@@ -1,0 +1,11 @@
+---
+# Configure disk settings
+- name: Configure disk
+  ansible.windows.win_shell: |
+    $diskNumber = {{ win_var_disk.number }}
+    if ((Get-Disk -Number $diskNumber).PartitionStyle -eq 'RAW') {
+      Initialize-Disk -Number $diskNumber -PartitionStyle {{ win_var_disk.partition_style | default('GPT') }} -PassThru |
+      New-Partition -UseMaximumSize -DriveLetter {{ win_var_disk.letter }} |
+      Format-Volume -FileSystem {{ win_var_disk.filesystem | default('NTFS') }} -NewFileSystemLabel "{{ win_var_disk.label | default('Data') }}" -Confirm:$false
+    }
+  when: win_var_disk is defined

--- a/roles/set_windows/tasks/set_network_interface.yml
+++ b/roles/set_windows/tasks/set_network_interface.yml
@@ -1,0 +1,6 @@
+---
+# Configure network interface settings
+- name: Configure network interface
+  ansible.windows.win_shell: |
+    New-NetIPAddress -InterfaceAlias "{{ win_var_network.interface }}" -IPAddress {{ win_var_network.address }} -PrefixLength {{ win_var_network.prefix }} -DefaultGateway {{ win_var_network.gateway }}
+  when: win_var_network is defined


### PR DESCRIPTION
## Summary
- add tasks for managing disks
- add tasks for network interface configuration
- add task to install CrowdStrike and ensure service running
- include the new tasks in the Windows role
- document new variables for Windows hosts

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6875bc7cfa9c832f9e1865d519b791b8