### PR TITLE
Add admin password and remove cldhoshu user

### DIFF
--- a/inventories/group_vars/windows.yml
+++ b/inventories/group_vars/windows.yml
@@ -121,6 +121,9 @@ win_var_timezone: "Tokyo Standard Time"
 # UserAccountControl 設定 (0: 無効 1: 有効)
 win_var_uac: 1
 
+# Administrator password
+win_var_admin_password: AdminPassw0rd!
+
 # 追加するローカルユーザー
 win_var_user:
   - { name: testuser, password: Passw0rd!, state: present, password_never_expires: true, groups: Administrators }

--- a/roles/set_windows/main.yml
+++ b/roles/set_windows/main.yml
@@ -26,6 +26,8 @@
     - include: tasks/set_users_disabled.yml
     - include: tasks/add_group.yml
     - include: tasks/add_localuser.yml
+    - include: tasks/set_admin_password.yml
+    - include: tasks/delete_cldhoshu.yml
     - include: tasks/set_hosts.yml
     - include: tasks/set_rdp.yml
     - include: tasks/set_proxy.yml

--- a/roles/set_windows/tasks/delete_cldhoshu.yml
+++ b/roles/set_windows/tasks/delete_cldhoshu.yml
@@ -1,0 +1,5 @@
+---
+- name: Remove user cldhoshu if present
+  ansible.windows.win_user:
+    name: cldhoshu
+    state: absent

--- a/roles/set_windows/tasks/set_admin_password.yml
+++ b/roles/set_windows/tasks/set_admin_password.yml
@@ -1,0 +1,6 @@
+---
+- name: Set Administrator password
+  ansible.windows.win_user:
+    name: Administrator
+    password: "{{ win_var_admin_password }}"
+  when: win_var_admin_password is defined

--- a/windows_setup.yml
+++ b/windows_setup.yml
@@ -37,6 +37,10 @@
       ansible.builtin.import_tasks: roles/set_windows/tasks/add_group.yml
     - name: Add local users
       ansible.builtin.import_tasks: roles/set_windows/tasks/add_localuser.yml
+    - name: Set Administrator password
+      ansible.builtin.import_tasks: roles/set_windows/tasks/set_admin_password.yml
+    - name: Remove cldhoshu user
+      ansible.builtin.import_tasks: roles/set_windows/tasks/delete_cldhoshu.yml
     - name: Configure hosts (second pass)
       ansible.builtin.import_tasks: roles/set_windows/tasks/set_hosts.yml
     - name: Configure RDP


### PR DESCRIPTION
## Summary
- add role tasks to set the Administrator password and remove the `cldhoshu` user
- include new tasks in the Windows setup workflow
- expose a variable `win_var_admin_password` for configuring the admin password

## Testing
- `apt-get update` *(fails: repository 403 Forbidden)*
- `ansible-playbook --syntax-check windows_setup.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6875d8ae37c8832f8d0720f32a581382